### PR TITLE
Add search filtering for templates API

### DIFF
--- a/COMPREHENSIVE_API_DOCUMENTATION.md
+++ b/COMPREHENSIVE_API_DOCUMENTATION.md
@@ -160,7 +160,7 @@ Get templates with filtering and sorting.
 
 **Query Parameters:**
 - `category`: Filter by template category
-- `search`: Text search in title/tags
+- `search`: Case-insensitive search on template titles and tags
 - `tags`: Comma-separated tag filter
 - `creator_id`: Filter by creator
 - `is_public`: Public/private filter

--- a/backend/server.py
+++ b/backend/server.py
@@ -207,6 +207,7 @@ async def import_from_url(
 @api_router.get("/templates")
 async def get_templates(
     category: Optional[str] = None,
+    search: Optional[str] = None,
     limit: int = Query(20, ge=1, le=100),
     skip: int = Query(0, ge=0),
     db=Depends(get_database)
@@ -216,7 +217,14 @@ async def get_templates(
         filter_query = {}
         if category:
             filter_query["category"] = category
-        
+
+        if search:
+            # Case-insensitive search on title and tags
+            filter_query["$or"] = [
+                {"title": {"$regex": search, "$options": "i"}},
+                {"tags": {"$regex": search, "$options": "i"}},
+            ]
+
         cursor = db.templates.find(filter_query).skip(skip).limit(limit)
         templates = await cursor.to_list(length=None)
         


### PR DESCRIPTION
## Summary
- allow `/api/templates` to accept `search` parameter and filter titles and tags
- document the `search` query parameter in API docs

## Testing
- `python -m py_compile backend/server.py`
- `python - <<'PY'
from backend_test import MotionEditAPITester
PY` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests: 403 Forbidden)*
- `curl -i "https://motion-templates-2.preview.emergentagent.com/api/templates?search=chart" -o /tmp/curl.log` *(fails: CONNECT tunnel failed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b4826910832182882e2c2ccd3ffa