### PR TITLE
Handle uppercase upload extensions

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -380,7 +380,8 @@ async def upload_template(
     """Upload and process a Lottie template file"""
     try:
         # Validate file type
-        if not (file.filename.endswith('.json') or file.filename.endswith('.lottie')):
+        filename_lower = file.filename.lower()
+        if not (filename_lower.endswith('.json') or filename_lower.endswith('.lottie')):
             raise HTTPException(status_code=400, detail="Only .json and .lottie files are supported")
         
         # Generate unique filename
@@ -402,7 +403,7 @@ async def upload_template(
         preview_video_url = ""
         
         # Generate proper slug
-        base_name = file.filename.replace('.json', '').replace('.lottie', '')
+        base_name = filename_lower.replace('.json', '').replace('.lottie', '')
         safe_slug = base_name.lower().replace(' ', '-').replace('_', '-')
         safe_slug = ''.join(c for c in safe_slug if c.isalnum() or c == '-')
         
@@ -460,6 +461,7 @@ async def import_from_url(
         from urllib.parse import urlparse
         parsed_url = urlparse(url)
         filename = Path(parsed_url.path).name or "imported_animation.json"
+        filename_lower = filename.lower()
         
         # Save locally
         file_hash = hashlib.md5(url.encode()).hexdigest()[:8]
@@ -473,13 +475,13 @@ async def import_from_url(
         preview_url = f"/uploads/previews/{unique_filename}.png"
         
         # Generate proper slug
-        base_name = filename.replace('.json', '').replace('.lottie', '')
+        base_name = filename_lower.replace('.json', '').replace('.lottie', '')
         safe_slug = base_name.lower().replace(' ', '-').replace('_', '-')
         safe_slug = ''.join(c for c in safe_slug if c.isalnum() or c == '-')
         
         # Create template record
         template_data = {
-            "title": filename.replace('.json', '').replace('.lottie', ''),
+            "title": base_name,
             "description": f"Imported from URL: {url}",
             "tags": [],
             "source": "url",

--- a/frontend/src/pages/UploadPage.js
+++ b/frontend/src/pages/UploadPage.js
@@ -39,8 +39,8 @@ const UploadPage = () => {
   const handleFiles = async (files) => {
     setIsProcessing(true);
     
-    const validFiles = files.filter(file => 
-      file.name.endsWith('.json') || file.name.endsWith('.lottie')
+    const validFiles = files.filter(file =>
+      file.name.toLowerCase().endsWith('.json') || file.name.toLowerCase().endsWith('.lottie')
     );
 
     if (validFiles.length === 0) {

--- a/tests/test_uppercase_uploads.py
+++ b/tests/test_uppercase_uploads.py
@@ -1,0 +1,121 @@
+import io
+import json
+import io
+import json
+import zipfile
+from datetime import datetime
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("UPLOADS_DIR", str(tmp_path))
+    sys.path.append(str(Path(__file__).resolve().parents[1] / "backend"))
+    # Provide a minimal aiohttp stub to satisfy imports in lottie_processor
+    import types
+    sys.modules.setdefault("aiohttp", types.SimpleNamespace(ClientSession=object))
+    # Stub modules that are heavy or have external dependencies
+    from dataclasses import dataclass, field
+    @dataclass
+    class _User:
+        id: str
+        email: str
+        full_name: str
+        subscription_tier: str = "free"
+        credits_remaining: int = 0
+        subscription_expires: None = None
+        created_at: datetime = field(default_factory=datetime.utcnow)
+        is_active: bool = True
+
+    sys.modules['auth'] = types.SimpleNamespace(
+        AuthService=object,
+        get_current_user=lambda: None,
+        get_current_user_optional=lambda: None,
+        User=_User,
+        UserCreate=object,
+        UserLogin=object,
+        GoogleAuthRequest=object,
+    )
+    from enum import Enum
+    class _SubTier(str, Enum):
+        FREE = "free"
+        MID = "mid"
+        PRO = "pro"
+    sys.modules['subscription'] = types.SimpleNamespace(SubscriptionService=object, SubscriptionTier=_SubTier)
+    sys.modules['payments'] = types.SimpleNamespace(PaymentService=object, PaymentIntent=object)
+    sys.modules['ai_service'] = types.SimpleNamespace(ai_service=object, AIPromptRequest=object)
+    sys.modules['export_service'] = types.SimpleNamespace(ExportService=object)
+    class _FSM:
+        def __init__(self, *args, **kwargs):
+            pass
+    sys.modules['file_storage'] = types.SimpleNamespace(FileStorageManager=_FSM)
+    import os
+    os.makedirs("/app/exports", exist_ok=True)
+    import json as _json
+    from datetime import datetime as _dt
+    _orig_dumps = _json.dumps
+    def _dumps(obj, *args, **kwargs):
+        kwargs.setdefault('default', lambda o: o.isoformat() if isinstance(o, _dt) else str(o))
+        return _orig_dumps(obj, *args, **kwargs)
+    _json.dumps = _dumps
+    import models
+    models.get_database = lambda: None
+    import builtins
+    builtins.get_database = lambda: None
+    import server
+    importlib.reload(server)
+    del builtins.get_database
+
+    async def override_user():
+        return server.User(
+            id="test-user",
+            email="test@example.com",
+            full_name="Test User",
+            subscription_tier="free",
+            credits_remaining=0,
+            subscription_expires=None,
+            created_at=datetime.utcnow(),
+            is_active=True,
+        )
+
+    server.app.dependency_overrides[server.get_current_user] = override_user
+
+    with TestClient(server.app) as c:
+        yield c
+
+    server.app.dependency_overrides.clear()
+
+
+def _basic_lottie_dict():
+    return {"v": "5.7.4", "fr": 30, "ip": 0, "op": 1, "w": 100, "h": 100, "layers": []}
+
+
+def test_upload_uppercase_json(client):
+    data = json.dumps(_basic_lottie_dict()).encode("utf-8")
+    file_obj = io.BytesIO(data)
+    response = client.post(
+        "/api/templates/upload",
+        files={"file": ("sample.JSON", file_obj, "application/json")},
+        data={"source": "upload"},
+    )
+    assert response.status_code == 200
+    assert response.json()["name"] == "sample"
+
+
+def test_upload_uppercase_lottie(client):
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("data.json", json.dumps(_basic_lottie_dict()))
+    buffer.seek(0)
+    response = client.post(
+        "/api/templates/upload",
+        files={"file": ("anim.LOTTIE", buffer, "application/octet-stream")},
+        data={"source": "upload"},
+    )
+    assert response.status_code == 200
+    assert response.json()["name"] == "anim"


### PR DESCRIPTION
## Summary
- Normalize filenames to lowercase for extension checks and slug generation in template uploads and URL imports
- Allow .JSON and .LOTTIE files in the upload page by lowercasing filenames before filtering
- Add regression tests ensuring uppercase extensions are accepted

## Testing
- `pytest tests/test_uppercase_uploads.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c60a4296408321b69e07fa494d73fb