### PR TITLE
Handle upload auth failures

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -374,11 +374,13 @@ async def confirm_paypal_payment(
 async def upload_template(
     file: UploadFile = File(...),
     source: str = Form("upload"),
-    current_user: User = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_optional),
     db=Depends(get_database)
 ):
     """Upload and process a Lottie template file"""
     try:
+        if current_user is None:
+            raise HTTPException(status_code=401, detail="Authentication required to upload templates")
         # Validate file type
         if not (file.filename.endswith('.json') or file.filename.endswith('.lottie')):
             raise HTTPException(status_code=400, detail="Only .json and .lottie files are supported")
@@ -800,6 +802,8 @@ async def bulk_import_upload(
     current_user: Optional[User] = Depends(get_current_user_optional)
 ):
     """Enhanced bulk upload with authentication"""
+    if current_user is None:
+        raise HTTPException(status_code=401, detail="Authentication required to upload files")
     results = []
     
     for file in files:

--- a/frontend/src/pages/ImportPage.js
+++ b/frontend/src/pages/ImportPage.js
@@ -43,10 +43,10 @@ const ImportPage = () => {
       files.forEach(file => {
         formData.append('files', file);
       });
-      
+
       // Upload files
       const response = await apiService.bulkImportUpload(formData);
-      
+
       // Process results
       const processedFiles = response.results.map((result, index) => ({
         id: Date.now() + index,
@@ -71,6 +71,11 @@ const ImportPage = () => {
       }
       
     } catch (error) {
+      if (error.response?.status === 401) {
+        alert('Please log in to upload files.');
+        window.location.href = '/';
+        return;
+      }
       console.error('Upload failed:', error);
       alert('Upload failed. Please try again.');
     } finally {

--- a/frontend/src/pages/UploadPage.js
+++ b/frontend/src/pages/UploadPage.js
@@ -91,8 +91,16 @@ const UploadPage = () => {
     const formData = new FormData();
     formData.append('file', file);
     formData.append('source', source);
-    
-    const result = await apiService.uploadTemplate(formData);
+    let result;
+    try {
+      result = await apiService.uploadTemplate(formData);
+    } catch (error) {
+      if (error.response?.status === 401) {
+        alert('Please log in to upload templates.');
+        window.location.href = '/';
+      }
+      throw error;
+    }
 
     // Generate previews client-side: last-frame PNG + 2.5s WebM
     try {


### PR DESCRIPTION
## Summary
- return 401 with clear message if uploading without authentication
- surface auth errors in upload pages and redirect users to sign in

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*
- `npm test -- --watchAll=false` *(fails: sh: 1: craco: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@craco%2fcraco)*

------
https://chatgpt.com/codex/tasks/task_e_68c60a429c048321ae41de2e66868877