### PR TITLE
Ensure uploads use backend base in Lottie renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # Here are your Instructions
+
+## Deployment
+
+When deploying the application, ensure that uploaded files are served directly by the backend rather than through the frontend's
+single-page application router. Static files live under the `/uploads/` path and should be mapped before the catch-all route
+used by the frontend.
+
+1. Build the frontend with the `REACT_APP_BACKEND_URL` environment variable pointing to the backend's public URL.
+2. Configure your web server or reverse proxy to serve the `/uploads/` directory from the backend filesystem.
+
+Example **nginx** configuration:
+
+```
+location /uploads/ {
+    alias /path/to/backend/uploads/;
+    add_header Cache-Control no-cache;
+}
+
+location / {
+    try_files $uri /index.html;
+}
+```
+
+With this setup, requests like `/uploads/...` bypass the frontend router and return the corresponding file from the backend.

--- a/frontend/src/components/editor/LottieRenderer.js
+++ b/frontend/src/components/editor/LottieRenderer.js
@@ -67,12 +67,13 @@ const LottieRenderer = ({
           const response = await fetch(`${backendBase}/api/lottiefiles/animation/${animationId}/data`);
           if (!response.ok) throw new Error(`Failed to load embedded animation: ${response.status}`);
           data = await response.json();
-        } else if (sourceUrl.startsWith('/uploads/')) {
-          const response = await fetch(`${backendBase}${sourceUrl}`);
-          if (!response.ok) throw new Error(`Failed to load animation: ${response.status}`);
-          data = await response.json();
         } else {
-          const response = await fetch(sourceUrl);
+          let resolvedUrl = sourceUrl;
+          if (resolvedUrl.startsWith('/uploads/')) {
+            resolvedUrl = `${backendBase}${resolvedUrl}`;
+          }
+
+          const response = await fetch(resolvedUrl);
           if (!response.ok) throw new Error(`Failed to load animation: ${response.status}`);
           data = await response.json();
         }


### PR DESCRIPTION
## Summary
- Prefix `/uploads` sources with backend base URL in LottieRenderer
- Document deployment so static uploads bypass frontend router

## Testing
- `npm test -- --watchAll=false` *(fails: craco not found)*
- `yarn install` *(fails: cannot download yarn 1.22.22 - Proxy response (403) !== 200 when HTTP Tunneling)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c60a4499048321af6536590ee83113