### PR TITLE
Use window origin for API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ When deploying the application, ensure that uploaded files are served directly b
 single-page application router. Static files live under the `/uploads/` path and should be mapped before the catch-all route
 used by the frontend.
 
-1. Build the frontend with the `REACT_APP_BACKEND_URL` environment variable pointing to the backend's public URL.
+1. API requests default to the same origin (`window.location.origin`). For cross-domain deployments, build the frontend with the `REACT_APP_BACKEND_URL` environment variable pointing to the backend's public URL (e.g., `REACT_APP_BACKEND_URL=https://api.example.com`).
 2. Configure your web server or reverse proxy to serve the `/uploads/` directory from the backend filesystem.
 
 Example **nginx** configuration:

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const baseURL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:8001';
+const baseURL = process.env.REACT_APP_BACKEND_URL || window.location.origin;
 
 const api = axios.create({
   baseURL: `${baseURL}/api`,


### PR DESCRIPTION
## Summary
- Default API base URL to `window.location.origin`
- Document overriding API base URL with `REACT_APP_BACKEND_URL`

## Testing
- `CI=true npm test` *(fails: craco not found)*
- `npm install --no-package-lock` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@craco%2fcraco)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a1225bcc8321b55217d8c04ece75