### PR TITLE
Avoid filename collisions by hashing content

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -465,13 +465,14 @@ async def import_from_url(
         filename = Path(parsed_url.path).name or "imported_animation.json"
         filename_lower = filename.lower()
         
-        # Save locally
-        file_hash = hashlib.md5(url.encode()).hexdigest()[:8]
+        # Save locally using a content hash to avoid name collisions
+        content = json.dumps(animation_data, sort_keys=True, indent=2)
+        file_hash = hashlib.md5(content.encode()).hexdigest()[:8]
         unique_filename = f"{file_hash}_{filename}"
         file_path = UPLOADS_DIR / unique_filename
-        
+
         async with aiofiles.open(file_path, 'w') as f:
-            await f.write(json.dumps(animation_data, indent=2))
+            await f.write(content)
         
         # Generate preview
         preview_url = f"/uploads/previews/{unique_filename}.png"

--- a/tests/test_animation_collision.py
+++ b/tests/test_animation_collision.py
@@ -1,0 +1,61 @@
+import os
+from pathlib import Path
+from importlib import reload
+
+from fastapi.testclient import TestClient
+
+
+def create_app(tmp_path):
+    """Create a fresh FastAPI app instance using a temporary upload directory."""
+    os.environ["UPLOADS_DIR"] = str(tmp_path)
+
+    from backend import server as server_module
+
+    reload(server_module)
+
+    # Override authentication dependency to bypass token checks
+    from backend.models import User
+
+    async def override_get_current_user():
+        return User(id="test-user", email="test@example.com", full_name="Test User")
+
+    server_module.app.dependency_overrides[server_module.get_current_user] = override_get_current_user
+    return server_module.app
+
+
+def test_animation_json_collisions(tmp_path):
+    app = create_app(tmp_path)
+
+    file_content_1 = b'{"v":"5","fr":30,"ip":0,"op":10,"w":100,"h":100,"layers":[]}'
+    file_content_2 = b'{"v":"5","fr":30,"ip":0,"op":20,"w":200,"h":100,"layers":[]}'
+
+    headers = {"Authorization": "Bearer test"}
+
+    with TestClient(app) as client:
+        resp1 = client.post(
+            "/api/templates/upload",
+            files={"file": ("animation.json", file_content_1, "application/json")},
+            data={"source": "upload"},
+            headers=headers,
+        )
+        assert resp1.status_code == 200, resp1.text
+
+        resp2 = client.post(
+            "/api/templates/upload",
+            files={"file": ("animation.json", file_content_2, "application/json")},
+            data={"source": "upload"},
+            headers=headers,
+        )
+        assert resp2.status_code == 200, resp2.text
+
+    url1 = resp1.json()["file_url"]
+    url2 = resp2.json()["file_url"]
+
+    assert url1 != url2
+
+    path1 = tmp_path / Path(url1).name
+    path2 = tmp_path / Path(url2).name
+
+    assert path1.read_bytes() == file_content_1
+    assert path2.read_bytes() == file_content_2
+


### PR DESCRIPTION
## Summary
- Hash imported template URL content instead of the URL itself
- Add regression test to ensure different animation.json files don't overwrite

## Testing
- `pytest tests/test_animation_collision.py tests/test_file_collision.py tests/test_uppercase_uploads.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi pytest aiofiles python-multipart uvicorn` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a1229c5c8321ae7e486822cee2e5