### PR TITLE
Handle 401 on URL import

### DIFF
--- a/frontend/src/pages/UploadPage.js
+++ b/frontend/src/pages/UploadPage.js
@@ -69,13 +69,20 @@ const UploadPage = () => {
 
   const handleUrlImport = async () => {
     if (!urlInput.trim()) return;
-    
+
     setIsProcessing(true);
     try {
       const result = await apiService.importFromUrl(urlInput);
       setUploadedFiles(prev => [...prev, result]);
       setUrlInput('');
     } catch (error) {
+      if (error.response?.status === 401) {
+        alert('Please log in to import templates.');
+        setIsProcessing(false);
+        const returnUrl = encodeURIComponent(window.location.pathname);
+        window.location.href = `/login?returnUrl=${returnUrl}`;
+        return;
+      }
       console.error('URL import error:', error);
       setUploadedFiles(prev => [...prev, {
         id: Date.now() + Math.random(),


### PR DESCRIPTION
## Summary
- catch 401 responses from import URL and prompt user to log in
- redirect unauthenticated URL imports to login with return URL

## Testing
- `npm test -- --watchAll=false` *(fails: craco not found)*
- `yarn install` *(fails: Proxy response (403) when downloading yarn)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a122f1148321a3bfc1999d887281