### PR TITLE
Allow anonymous template uploads

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -379,8 +379,6 @@ async def upload_template(
 ):
     """Upload and process a Lottie template file"""
     try:
-        if current_user is None:
-            raise HTTPException(status_code=401, detail="Authentication required to upload templates")
         # Validate file type
         filename_lower = file.filename.lower()
         if not (filename_lower.endswith('.json') or filename_lower.endswith('.lottie')):
@@ -417,7 +415,7 @@ async def upload_template(
             "source": source,
             "license": "",
             "author": "",
-            "creator_id": current_user.id,
+            "creator_id": current_user.id if current_user else "anonymous",
             "file_url": f"/uploads/{unique_filename}",
             "preview_url": preview_url,
             "manifest": manifest,


### PR DESCRIPTION
## Summary
- Allow `/templates/upload` endpoint to accept uploads without authentication
- Default `creator_id` to the uploader's id or `'anonymous'`

## Testing
- `pytest tests -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi -q` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c24b962c83219fc255101c34517e