### PR TITLE
Remove login redirects from upload errors

### DIFF
--- a/frontend/src/pages/UploadPage.js
+++ b/frontend/src/pages/UploadPage.js
@@ -76,14 +76,8 @@ const UploadPage = () => {
       setUploadedFiles(prev => [...prev, result]);
       setUrlInput('');
     } catch (error) {
-      if (error.response?.status === 401) {
-        alert('Please log in to import templates.');
-        setIsProcessing(false);
-        const returnUrl = encodeURIComponent(window.location.pathname);
-        window.location.href = `/login?returnUrl=${returnUrl}`;
-        return;
-      }
       console.error('URL import error:', error);
+      alert('Import failed. Please try again.');
       setUploadedFiles(prev => [...prev, {
         id: Date.now() + Math.random(),
         name: urlInput,
@@ -102,10 +96,7 @@ const UploadPage = () => {
     try {
       result = await apiService.uploadTemplate(formData);
     } catch (error) {
-      if (error.response?.status === 401) {
-        alert('Please log in to upload templates.');
-        window.location.href = '/';
-      }
+      alert('Upload failed. Please try again.');
       throw error;
     }
 


### PR DESCRIPTION
## Summary
- replace URL import login redirect with neutral alert
- replace file upload login redirect with neutral alert

## Testing
- `npm test -- --watchAll=false` *(fails: craco not found)*
- `npm install` *(fails: 403 Forbidden - @craco/craco)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c259bba483219fc70775e85c3b90