### PR TITLE
Wrap app with AuthProvider

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,6 +20,7 @@ import LoginModal from './components/auth/LoginModal';
 import RegisterModal from './components/auth/RegisterModal';
 import SubscriptionModal from './components/subscription/SubscriptionModal';
 import SubscriptionBanner from './components/subscription/SubscriptionBanner';
+import { useAuth } from './contexts/AuthContext';
 
 // Import pages
 import LibraryPage from './pages/LibraryPage';

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,10 +2,13 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
+import { AuthProvider } from "./contexts/AuthContext";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- import useAuth in App component
- wrap React root with AuthProvider to expose auth context

## Testing
- `npm test -- --watchAll=false` *(fails: craco not found)*
- `npm install` *(fails: 403 Forbidden fetching @craco/craco)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e7b045008321a04857f5e109955d